### PR TITLE
Return statement to prevent app from further doing changes in Single Instance Check

### DIFF
--- a/main.js
+++ b/main.js
@@ -14,7 +14,7 @@ let quittingApp = false;
 
 var myWindow = null;
 
-if (process.argv[2] == "true") {
+if (process.argv[3] == "true") {
   var shouldQuit = app.makeSingleInstance(function(commandLine, workingDirectory) {
     // Someone tried to run a second instance, we should focus our window.
     if (myWindow) {
@@ -518,6 +518,7 @@ function windowCreateFinish(json) {
             url: url
         })
     })
+    myWindow = elements[json.targetID];
 }
 
 function registerCallback(json, k, e, n, c) {

--- a/main.js
+++ b/main.js
@@ -12,8 +12,25 @@ let elements = {};
 let menus = {};
 let quittingApp = false;
 
+var myWindow = null;
+
+if (process.argv[2] == "true") {
+  var shouldQuit = app.makeSingleInstance(function(commandLine, workingDirectory) {
+    // Someone tried to run a second instance, we should focus our window.
+    if (myWindow) {
+      if (myWindow.isMinimized()) myWindow.restore();
+      myWindow.focus();
+    }
+  });
+
+  if (shouldQuit) {
+    app.quit();
+    return;
+  }
+}
+
 // Command line switches
-let idx = 3;
+let idx = 4;
 for (let i = idx; i < process.argv.length; i++) {
     let s = process.argv[i].replace(/^[\-]+/g,"");
     let v;

--- a/main.js
+++ b/main.js
@@ -14,7 +14,8 @@ let quittingApp = false;
 
 var myWindow = null;
 
-if (process.argv[2] == "true") {
+// parsing for the option of SingleInstance "true" or null
+if (process.argv[3] === "true") {
   var shouldQuit = app.makeSingleInstance(function(commandLine, workingDirectory) {
     // Someone tried to run a second instance, we should focus our window.
     if (myWindow) {
@@ -518,6 +519,7 @@ function windowCreateFinish(json) {
             url: url
         })
     })
+    myWindow = elements[json.targetID]
 }
 
 function registerCallback(json, k, e, n, c) {

--- a/main.js
+++ b/main.js
@@ -25,7 +25,6 @@ if (process.argv[3] == "true") {
 
   if (shouldQuit) {
     app.quit();
-    return;
   }
 }
 

--- a/main.js
+++ b/main.js
@@ -26,6 +26,7 @@ if (process.argv[3] === "true") {
 
   if (shouldQuit) {
     app.quit();
+    return;
   }
 }
 

--- a/main.js
+++ b/main.js
@@ -518,11 +518,7 @@ function windowCreateFinish(json) {
             url: url
         })
     })
-<<<<<<< HEAD
-    myWindow = elements[json.targetID];
-=======
     myWindow = elements[json.targetID]
->>>>>>> master
 }
 
 function registerCallback(json, k, e, n, c) {


### PR DESCRIPTION
I took the latest and was testing the app. I found that we need a return statement after quitting the app so that app does not handle further events.