### PR TITLE
support websocket over tls

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,5 +16,8 @@
   "main": "index.js",
   "peerDependencies": {
     "electron": ">=1.8.1"
+  },
+  "dependencies": {
+    "ws": "^7.4.2"
   }
 }

--- a/src/client.js
+++ b/src/client.js
@@ -2,14 +2,23 @@
 
 const net = require("net");
 const url = require("url");
+const WebSocket = require("ws");
 
 // Client can read/write messages from a TCP server
 class Client {
   // init initializes the Client
   init(addr) {
-    let u = url.parse("tcp://" + addr, false, false);
-    this.socket = new net.Socket();
-    this.socket.connect(u.port, u.hostname, function() {});
+    if(addr.indexOf('wss://') == 0) {
+      const ws = new WebSocket(addr, {
+        origin: addr.replace('wss://', 'https://'),
+        rejectUnauthorized: false
+      });
+      this.socket = WebSocket.createWebSocketStream(ws);
+    } else {
+      let u = url.parse("tcp://" + addr, false, false);
+      this.socket = new net.Socket();
+      this.socket.connect(u.port, u.hostname, function() {});  
+    }
     this.socket.on("close", function() {
       process.exit();
     });


### PR DESCRIPTION
#36 

Use [ws](https://www.npmjs.com/package/ws) to create websocket client with stream API,

and language binding side should implement server side for supporting websocket over TLS, wss://localhost:port

