### PR TITLE
Ensure element exists before trying to send message

### DIFF
--- a/index.js
+++ b/index.js
@@ -248,9 +248,7 @@ function onReady () {
             let m = {message: json.message}
             if (typeof json.callbackId !== "undefined") m.callbackId = json.callbackId
             const targetElement = elements[json.targetID]
-            if (targetElement) {
-                targetElement.webContents.send(json.name === consts.eventNames.windowCmdMessageCallback ? consts.eventNames.ipcCmdMessageCallback : consts.eventNames.ipcCmdMessage, m)
-            }
+            if (targetElement) targetElement.webContents.send(json.name === consts.eventNames.windowCmdMessageCallback ? consts.eventNames.ipcCmdMessageCallback : consts.eventNames.ipcCmdMessage, m)
             break;
             case consts.eventNames.windowCmdMinimize:
             elements[json.targetID].minimize()

--- a/index.js
+++ b/index.js
@@ -247,7 +247,10 @@ function onReady () {
             case consts.eventNames.windowCmdMessageCallback:
             let m = {message: json.message}
             if (typeof json.callbackId !== "undefined") m.callbackId = json.callbackId
-            elements[json.targetID].webContents.send(json.name === consts.eventNames.windowCmdMessageCallback ? consts.eventNames.ipcCmdMessageCallback : consts.eventNames.ipcCmdMessage, m)
+            const targetElement = elements[json.targetID]
+            if (targetElement) {
+                targetElement.webContents.send(json.name === consts.eventNames.windowCmdMessageCallback ? consts.eventNames.ipcCmdMessageCallback : consts.eventNames.ipcCmdMessage, m)
+            }
             break;
             case consts.eventNames.windowCmdMinimize:
             elements[json.targetID].minimize()


### PR DESCRIPTION
If a request is in progress from a window when the window is closed, the response will cause an unhanded javascript exception popup. This PR avoids the unhandled exception by first checking that the element exists before accessing `webContents`.
