### PR TITLE
Prevent Uncaught Exception caused by TCP Error

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -9,11 +9,11 @@ class Client {
   init(addr) {
     let u = url.parse("tcp://" + addr, false, false);
     this.socket = new net.Socket();
-    this.socket.connect(u.port, u.hostname, function () {});
-    this.socket.on("close", function () {
+    this.socket.connect(u.port, u.hostname, function() {});
+    this.socket.on("close", function() {
       process.exit();
     });
-    this.socket.on("error", function () {
+    this.socket.on("error", function() {
       // Prevent Unhandled Exception resulting from TCP Error
     });
     return this;
@@ -21,7 +21,7 @@ class Client {
 
   // write writes an event to the server
   write(targetID, eventName, payload) {
-    if (this.socket.destroyed) return;
+    if(this.socket.destroyed) return;
     let data = { name: eventName, targetID: targetID };
     if (typeof payload !== "undefined") Object.assign(data, payload);
     this.socket.write(JSON.stringify(data) + "\n");

--- a/src/client.js
+++ b/src/client.js
@@ -9,16 +9,19 @@ class Client {
   init(addr) {
     let u = url.parse("tcp://" + addr, false, false);
     this.socket = new net.Socket();
-    this.socket.connect(u.port, u.hostname, function() {});
-    this.socket.on("close", function() {
+    this.socket.connect(u.port, u.hostname, function () {});
+    this.socket.on("close", function () {
       process.exit();
+    });
+    this.socket.on("error", function () {
+      // Prevent Unhandled Exception resulting from TCP Error
     });
     return this;
   }
 
   // write writes an event to the server
   write(targetID, eventName, payload) {
-    if(this.socket.destroyed) return;
+    if (this.socket.destroyed) return;
     let data = { name: eventName, targetID: targetID };
     if (typeof payload !== "undefined") Object.assign(data, payload);
     this.socket.write(JSON.stringify(data) + "\n");

--- a/src/client.js
+++ b/src/client.js
@@ -13,8 +13,9 @@ class Client {
     this.socket.on("close", function() {
       process.exit();
     });
-    this.socket.on("error", function() {
+    this.socket.on("error", function(err) {
       // Prevent Unhandled Exception resulting from TCP Error
+      console.error(err);
     });
     return this;
   }


### PR DESCRIPTION
In our application we occasionally encounter an Uncaught Exception due to an `ECONNRESET` error when the tcp connection between the client and the main electron process is lost.


Write ->
![image](https://user-images.githubusercontent.com/73299491/110397554-1005a600-8040-11eb-9bf0-47b6bda2c9e9.png)


Read ->
![image](https://user-images.githubusercontent.com/73299491/110397618-2a3f8400-8040-11eb-867a-babcae7834fb.png)


In order to prevent this from being shown to the end user we are suggesting that this error be suppressed.  Since the socket "close" event will be fired immediately after the socket "error" event, `process.exit()` will be called as soon as there is an error with the tcp connection.
We are open to other methods of suppressing this exception or adding this as configuration functionality.