### PR TITLE
Force disable context isolation

### DIFF
--- a/index.js
+++ b/index.js
@@ -401,6 +401,7 @@ function windowCreate(json) {
     if (!json.windowOptions.webPreferences) {
         json.windowOptions.webPreferences = {}
     }
+    json.windowOptions.webPreferences.contextIsolation = false
     json.windowOptions.webPreferences.nodeIntegration = true
     elements[json.targetID] = new BrowserWindow(json.windowOptions)
     windowOptions[json.targetID] = json.windowOptions


### PR DESCRIPTION
Disables [context isolation](https://www.electronjs.org/docs/tutorial/context-isolation) for Electron windows. It appears to be incompatible with astilectron, but it's enabled by default by Electron starting with major version 12.

See https://github.com/asticode/go-astilectron/issues/318#issuecomment-830764153