### PR TITLE
Facilitate running custom javascript on the main JS process

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,6 +104,26 @@ function onReady () {
             app.quit();
             break;
 
+            case consts.eventNames.appExecuteJavaScript:
+                (async function () {
+                    let evalAsync = (ev, json) => {
+                        return new Promise((resolve, reject) => {
+                            eval(ev);
+                        });
+                    };
+                    try {
+                        client.write(json.targetID, consts.eventNames.appExecuteJavaScriptCallback, {
+                            reply: await evalAsync(json.code, json)
+                        });
+                    } catch (error) {
+                        console.log(error);
+                        client.write(json.targetID, consts.eventNames.appExecuteJavaScriptCallback, {
+                            error: error.toString()
+                        });
+                    }
+                }());
+                break;
+
             // Dock
             case consts.eventNames.dockCmdBounce:
             let id = 0;

--- a/index.js
+++ b/index.js
@@ -116,7 +116,6 @@ function onReady () {
                             reply: await evalAsync(json.code, json)
                         });
                     } catch (error) {
-                        console.log(error);
                         client.write(json.targetID, consts.eventNames.appExecuteJavaScriptCallback, {
                             error: error.toString()
                         });

--- a/src/consts.js
+++ b/src/consts.js
@@ -9,6 +9,8 @@ module.exports = {
         appCmdQuit: "app.cmd.quit",
         appEventReady: "app.event.ready",
         appEventSecondInstance: "app.event.second.instance",
+        appExecuteJavaScript: "app.execute.javascript",
+        appExecuteJavaScriptCallback: "app.execute.javascript.callback",
         displayEventAdded: "display.event.added",
         displayEventMetricsChanged: "display.event.metrics.changed",
         displayEventRemoved: "display.event.removed",


### PR DESCRIPTION
I'm preparing another PR for go-astilectron that interfaces with this.

I figured this works well with astilectron's approach of forward compatibility. ie. electron can release new versions but astilectron doesn't necessarily need an update to support them. Unfortunately, this can leave you stranded if you want to user features in the new electron version.

Obviously this has all the established security caveats of using eval. That's a consideration for the developer who utilizes the code though, IMO.

Note that the code is written so that you have to call `resolve()` and `reject()` with the result. This is to facilitate asynchronous JavaScript code.

Very new to this codebase so please feel free to point out better ways of addressing this.